### PR TITLE
Fix github link on contact page

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -11,6 +11,6 @@ PGP: `FBBC A68D 3696 0A1A E525 A7AC 1138 6F17 941D 6EFC`
 
 IM: bumbleblue@jabber.zone
 
-[github]: https://github.com/gayanvirajith
+[github]: https://github.com/flapperleenie
 [twitter]: https://twitter.com/flapperleenie
 [ello]: https://ello.co/bumbleblue


### PR DESCRIPTION
The github link was still the same as in the Harmony template.
Changed to match github link in footer.
